### PR TITLE
Gotchas: Corrects equals signs error

### DIFF
--- a/latest/tutorial/gotchas.html
+++ b/latest/tutorial/gotchas.html
@@ -218,7 +218,7 @@ SymPy, <tt class="docutils literal"><span class="pre">==</span></tt> represents 
 the result of <tt class="docutils literal"><span class="pre">==</span></tt>.  There is a separate object, called <tt class="docutils literal"><span class="pre">Eq</span></tt>, which can be
 used to create symbolic equalities</p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">Eq</span><span class="p">(</span><span class="n">x</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
-<span class="go">x + 1 == 4</span>
+<span class="go">x+1 = 4</span>
 </pre></div>
 </div>
 <p>There is one additional caveat about <tt class="docutils literal"><span class="pre">==</span></tt> as well.  Suppose we want to know

--- a/latest/tutorial/gotchas.html
+++ b/latest/tutorial/gotchas.html
@@ -218,7 +218,7 @@ SymPy, <tt class="docutils literal"><span class="pre">==</span></tt> represents 
 the result of <tt class="docutils literal"><span class="pre">==</span></tt>.  There is a separate object, called <tt class="docutils literal"><span class="pre">Eq</span></tt>, which can be
 used to create symbolic equalities</p>
 <div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">Eq</span><span class="p">(</span><span class="n">x</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">4</span><span class="p">)</span>
-<span class="go">x+1 = 4</span>
+<span class="go">x + 1 = 4</span>
 </pre></div>
 </div>
 <p>There is one additional caveat about <tt class="docutils literal"><span class="pre">==</span></tt> as well.  Suppose we want to know


### PR DESCRIPTION
Error in Run code block in SymPy Live is corrected.
Eq(x + 1, 4) statement in SymPy Live yields x + 1 = 4
and not x + 1 == 4.

Fixes https://github.com/sympy/sympy_doc/issues/21
Fixes https://github.com/sympy/sympy/issues/10711
