### PR TITLE
Add robots.txt to tell search crawlers to not show old version docs

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,13 @@
+# Update this file when a new release is pushed
+
+User-agent: *
+Disallow: /0.6.7/
+Disallow: /0.7.0/
+Disallow: /0.7.1/
+Disallow: /0.7.2-py3k/
+Disallow: /0.7.2/
+Disallow: /0.7.3/
+Disallow: /0.7.4/
+Disallow: /0.7.5/
+Disallow: /0.7.6/
+Disallow: /dev/


### PR DESCRIPTION
@asmeurer This is an additional measure which will help.
