### PR TITLE
Update the README with there no longer being old versions in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ several things.
 
 ## Development docs
 
-These are the easiest.  Just build the docs from the latest SymPy master.
-Then, do
+**NOTE: The doctr command that runs on Travis on the sympy/sympy repo does
+this automatically. There is usually not a need to do this manually.**
+
+Build the docs from the latest SymPy master. Then, do
 
     rm -rf dev/
     cp -R ../path/to/sympy/doc/_build/html dev/
@@ -38,25 +40,35 @@ of index.html remains intact. Run
 
 ## Release docs
 
-This is harder, because you have to update the index.
+**NOTE: This should be done automatically by the SymPy release script. It
+should only be done manually if the release script doesn't do it correctly for
+some reason.**
 
-First, move the current latest docs to the version number (which should
-currently be a redirect to the `latest` docs).
+First, completely remove the old release docs
 
-    git rm -r 0.7.2/
-    git mv latest 0.7.3
+    git rm -rf latest/
 
 Checkout the SymPy release tag and build the docs as above.  Then do
+a
+    cp -R ../path/to/sympy/doc/_build/html latest/
 
-    cp -R ../path/to/sympy/doc/_build/html 0.7.3
-
-Edit `releases.txt` with the new release. Then run
+Then update the release versions in `releases.txt` and run
 
     ./generate_indexes.py
 
-Finally, you need to make sure the url with the latest version redirects to
-`latest`. This is easy. Just run `./generate_redirects.py 0.7.3 latest`, and
-commit the changes.
+And add the results
+
+    git add -A dev/ latest/ releases.txt
+
+## Making redirects
+
+The `generate_redirects.py` script can generate redirects from one path to
+another.
+
+We used to host old versions of the docs on this, but now we only host the
+latest and development docs. The old docs that were there have redirects to
+the latest docs. This is only done so that old links can continue to work. It
+is not necessary to add redirects for future versions.
 
 ## Pull requests
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -201,6 +201,7 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
             </a></p>
             <h4>Docs for other versions</h4>
             <p class="topless"><a href="../latest/index.html">Latest release (1.5.1)</a></p>
+            <p class="topless">Development version (1.6.dev)</p>
   <h4>Next topic</h4>
   <p class="topless"><a href="install.html"
                         title="next chapter">Installation</a></p>

--- a/dev/index.html
+++ b/dev/index.html
@@ -200,8 +200,8 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
               <img class="logo" src="_static/sympylogo.png" alt="Logo"/>
             </a></p>
             <h4>Documentation version</h4>
-            <p class="topless"><a href="../latest/index.html">Latest release (1.5.1)</a></p>
-            <p class="topless">Development version (1.6.dev)</p>
+            <p class="topless"><a href="../latest/index.html">SymPy 1.5.1 (latest release)</a></p>
+            <p class="topless">SymPy 1.6.dev (development version)</p>
   <h4>Next topic</h4>
   <p class="topless"><a href="install.html"
                         title="next chapter">Installation</a></p>

--- a/dev/index.html
+++ b/dev/index.html
@@ -199,7 +199,7 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
             <p class="logo"><a href="#">
               <img class="logo" src="_static/sympylogo.png" alt="Logo"/>
             </a></p>
-            <h4>Docs for other versions</h4>
+            <h4>Documentation version</h4>
             <p class="topless"><a href="../latest/index.html">Latest release (1.5.1)</a></p>
             <p class="topless">Development version (1.6.dev)</p>
   <h4>Next topic</h4>

--- a/generate_indexes.py
+++ b/generate_indexes.py
@@ -74,11 +74,14 @@ def main():
         del lines[inserti:endi]
         for insertreleasedir, insertrelease in reversed(releases):
             if insertreleasedir == releasedir:
-                continue
-            lines.insert(inserti, '            <p class="topless"><a href="../{0}/index.html">{1}</a></p>\n'.format(
-                insertreleasedir,
-                insertrelease
-            ))
+                lines.insert(inserti, '            <p class="topless">{0}</p>\n'.format(
+                    insertrelease
+                ))
+            else:
+                lines.insert(inserti, '            <p class="topless"><a href="../{0}/index.html">{1}</a></p>\n'.format(
+                    insertreleasedir,
+                    insertrelease
+                ))
         lines.insert(inserti, "            <h4>Docs for other versions</h4>\n")
 
         # Write the changed file back out.

--- a/generate_indexes.py
+++ b/generate_indexes.py
@@ -61,7 +61,7 @@ def main():
             sys.exit(0)
 
         # Do we want to delete anything? Is there a table there already?
-        if "Docs for other versions" in lines[linei]:
+        if "Documentation version" in lines[linei]:
             # Where does the current table end?
             # We want endi to be the first line not part of the current table.
             while linei < len(lines):
@@ -82,7 +82,7 @@ def main():
                     insertreleasedir,
                     insertrelease
                 ))
-        lines.insert(inserti, "            <h4>Docs for other versions</h4>\n")
+        lines.insert(inserti, "            <h4>Documentation version</h4>\n")
 
         # Write the changed file back out.
         with codecs.open(os.path.join(releasedir, "index.html"), "w", "utf8") as f:

--- a/latest/index.html
+++ b/latest/index.html
@@ -199,8 +199,8 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
               <img class="logo" src="_static/sympylogo.png" alt="Logo"/>
             </a></p>
             <h4>Documentation version</h4>
-            <p class="topless">Latest release (1.5.1)</p>
-            <p class="topless"><a href="../dev/index.html">Development version (1.6.dev)</a></p>
+            <p class="topless">SymPy 1.5.1 (latest release)</p>
+            <p class="topless"><a href="../dev/index.html">SymPy 1.6.dev (development version)</a></p>
   <h4>Next topic</h4>
   <p class="topless"><a href="install.html"
                         title="next chapter">Installation</a></p>

--- a/latest/index.html
+++ b/latest/index.html
@@ -199,6 +199,7 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
               <img class="logo" src="_static/sympylogo.png" alt="Logo"/>
             </a></p>
             <h4>Docs for other versions</h4>
+            <p class="topless">Latest release (1.5.1)</p>
             <p class="topless"><a href="../dev/index.html">Development version (1.6.dev)</a></p>
   <h4>Next topic</h4>
   <p class="topless"><a href="install.html"

--- a/latest/index.html
+++ b/latest/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" type="text/css" href="https://live.sympy.org/static/live-core.css" />
     <link rel="stylesheet" type="text/css" href="https://live.sympy.org/static/live-autocomplete.css" />
     <link rel="stylesheet" type="text/css" href="https://live.sympy.org/static/live-sphinx.css" />
-    
+
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -24,13 +24,13 @@
     <script type="text/javascript" src="https://live.sympy.org/static/live-sphinx.js"></script>
     <script async="async" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML-full"></script>
     <script type="text/x-mathjax-config">MathJax.Hub.Config({"tex2jax": {"inlineMath": [["\\(", "\\)"]], "displayMath": [["\\[", "\\]"]]}})</script>
-    
+
     <link rel="shortcut icon" href="_static/sympy-notailtext-favicon.ico"/>
     <link href="https://docs.sympy.org/latest/index.html" rel="canonical" />
-    
+
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
-    <link rel="next" title="Installation" href="install.html" /> 
+    <link rel="next" title="Installation" href="install.html" />
   </head><body>
     <div class="related" role="navigation" aria-label="related navigation">
       <h3>Navigation</h3>
@@ -44,15 +44,15 @@
         <li class="right" >
           <a href="install.html" title="Installation"
              accesskey="N">next</a> |</li>
-        <li class="nav-item nav-item-0"><a href="#">SymPy 1.5.1 documentation</a> &#187;</li> 
+        <li class="nav-item nav-item-0"><a href="#">SymPy 1.5.1 documentation</a> &#187;</li>
       </ul>
-    </div>  
+    </div>
 
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
           <div class="body" role="main">
-            
+
   <span class="target" id="documentation"></span><div class="section" id="welcome-to-sympy-s-documentation">
 <h1>Welcome to SymPy’s documentation!<a class="headerlink" href="#welcome-to-sympy-s-documentation" title="Permalink to this headline">¶</a></h1>
 <p>A PDF version of these docs can be found <a class="reference external" href="https://github.com/sympy/sympy/releases">here</a>.</p>
@@ -198,7 +198,7 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
             <p class="logo"><a href="#">
               <img class="logo" src="_static/sympylogo.png" alt="Logo"/>
             </a></p>
-            <h4>Docs for other versions</h4>
+            <h4>Documentation version</h4>
             <p class="topless">Latest release (1.5.1)</p>
             <p class="topless"><a href="../dev/index.html">Development version (1.6.dev)</a></p>
   <h4>Next topic</h4>
@@ -237,7 +237,7 @@ If you are new to SymPy, start with the <a class="reference internal" href="tuto
         <li class="right" >
           <a href="install.html" title="Installation"
              >next</a> |</li>
-        <li class="nav-item nav-item-0"><a href="#">SymPy 1.5.1 documentation</a> &#187;</li> 
+        <li class="nav-item nav-item-0"><a href="#">SymPy 1.5.1 documentation</a> &#187;</li>
       </ul>
     </div>
     <div class="footer" role="contentinfo">

--- a/releases.txt
+++ b/releases.txt
@@ -1,2 +1,2 @@
-latest:Latest release (1.5.1)
-dev:Development version (1.6.dev)
+latest:SymPy 1.5.1 (latest release)
+dev:SymPy 1.6.dev (development version)


### PR DESCRIPTION
This is a followup to https://github.com/sympy/sympy_doc/pull/33 which updates the stuff in the README now that we don't serve old versions of the docs. 

We will also need to update the release script in sympy to edit `releases.txt` correctly and to not save the old `latest` as the previous version. The new process is actually simpler, so this should not be hard. 