### PR TITLE
Update generate_indexes.py to get the versions from the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Checkout the SymPy release tag and build the docs as above.  Then do
 a
     cp -R ../path/to/sympy/doc/_build/html latest/
 
-Then update the release versions in `releases.txt` and run
+Then run
 
     ./generate_indexes.py
 

--- a/releases.txt
+++ b/releases.txt
@@ -1,2 +1,0 @@
-latest:SymPy 1.6.2 (latest release)
-dev:SymPy 1.7.dev (development version)


### PR DESCRIPTION
Since we only serve 'latest' and 'dev' docs, there is no need to have a
separate file listing the releases.