### PR TITLE
Fixing ambiguity in the evalf example repetition

### DIFF
--- a/latest/modules/geometry/points.html
+++ b/latest/modules/geometry/points.html
@@ -476,7 +476,7 @@ the precision indicated (default=15).</p>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">p1</span> <span class="o">=</span> <span class="n">Point</span><span class="p">(</span><span class="n">Rational</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">2</span><span class="p">),</span> <span class="n">Rational</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">2</span><span class="p">))</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">p1</span>
 <span class="go">Point2D(1/2, 3/2)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">p1</span><span class="o">.</span><span class="n">evalf</span><span class="p">()</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">p1</span><span class="o">.</span><span class="n">n</span><span class="p">()</span>
 <span class="go">Point2D(0.5, 1.5)</span>
 </pre></div>
 </div>


### PR DESCRIPTION
With Reference to Issue #21246 of Sympy Repository.

In the Doc, the "n" method seems to have the example of the "evalf" method which is similar. Tested the code working with the n method and fixed it. 