### PR TITLE
fix generate_indexes.py after change to index page

### DIFF
--- a/generate_indexes.py
+++ b/generate_indexes.py
@@ -24,7 +24,8 @@ def main():
 
         # Find the release version
         for line in lines:
-            m = re.search(r"<title>Welcome to SymPy’s documentation! &#8212; SymPy (.*?) documentation</title>", line)
+            m = re.search(r'<a href="#">SymPy (.*?) documentation</a>', line)
+
             if m:
                 versions[releasedir] = m.group(1)
                 break


### PR DESCRIPTION
Currently the dev docs update in Travis is failing because it tries to parse the index page but the index page was changed in sympy master. This is an attempt to fix that parsing logic.