### PR TITLE
Fixed 404 ERROR from git "Configuration" URL in dev-setup.html

### DIFF
--- a/dev/contributing/new-contributors-guide/dev-setup.html
+++ b/dev/contributing/new-contributors-guide/dev-setup.html
@@ -887,7 +887,7 @@ shortcuts:</p>
 
 </pre></div>
 </div>
-<p>See <a class="reference external" href="https://git-scm.com/book/sv/v2/Customizing-Git-Git-Configuration">https://git-scm.com/book/sv/v2/Customizing-Git-Git-Configuration</a> for
+<p>See <a class="reference external" href="https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration">https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration</a> for
 some more common git configuration options.</p>
 </section>
 </section>


### PR DESCRIPTION
Changed link's git book language from "sv" (Swedish) to "en" (English), thus matching the (English) title of the linked page and eliminating a 404 error.